### PR TITLE
Upgrading PHP code from MySQL to MySQLi.

### DIFF
--- a/JSONtoMYSQL/lib/class.MySQLResult.php
+++ b/JSONtoMYSQL/lib/class.MySQLResult.php
@@ -12,17 +12,17 @@ class MySQLResult{
 
 	public function __construct($link, $result){
 		$this->result = $result;
-		$this->insert_id = @mysql_insert_id($link);
-		$this->affected_rows = @mysql_affected_rows($link);
+		$this->insert_id = @mysqli_insert_id($link);
+		$this->affected_rows = @mysqli_affected_rows($link);
 	}
 
 	
 	function num_rows(){
-		return mysql_num_rows($this->result);
+		return mysqli_num_rows($this->result);
 	}
 
 	function fetch_array(){
-		return mysql_fetch_array($this->result, MYSQL_ASSOC);
+		return mysqli_fetch_array($this->result, MYSQLI_ASSOC);
 	}
 	
 	function insert_id(){


### PR DESCRIPTION
Note:
The original MySQL extension is now deprecated, and will generate E_DEPRECATED errors (not warnings) when connecting to a database.

Instead, is needed to use the MySQLi or PDO_MySQL extensions.

I decided to use mysqli over PDO_MYSQL for adapting the code fast.

Also, we must take in mind that PDO_MYSQL hasn't got num_rows such as mysqli or mysql.

There is rowCount(), but doesn't work the same way.

See discussions on StackOverFlow:
https://stackoverflow.com/questions/883365/row-count-with-pdo

And PHP.net:
https://php.net/manual/en/pdostatement.rowcount.php#78338

So the code, must be debugged and reanalized before using PDO.